### PR TITLE
Exposes additional Manifest structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "binsync"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "bincode",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "binsync"
 description = "A library for syncing binary files between two locations."
-version = "0.0.3"
+version = "0.0.4"
 license = "Apache-2.0"
 edition = "2021"
 repository = "https://github.com/dristic/binsync"
@@ -9,19 +9,19 @@ readme = "README.md"
 exclude = ["examples/*", ".github/"]
 
 [dependencies]
-bincode = "1.3.3"
-clap = { version = "3.1.12", features = ["derive"] }
-fastcdc = "1.0.6"
+bincode = "^1"
+clap = { version = "^3", features = ["derive"] }
+fastcdc = "^1"
 indicatif = "0.16.2"
-md5 = "0.7.0"
-reqwest = { version = "0.11.10", optional = true, features = ["blocking"] }
-serde = { version = "1.0.136", features = ["derive"] }
-thiserror = "1.0.30"
-walkdir = "2.3.2"
+md5 = "^0.7"
+reqwest = { version = "^0.11", optional = true, features = ["blocking"] }
+serde = { version = "^1", features = ["derive"] }
+thiserror = "^1"
+walkdir = "^2"
 
 [dev-dependencies]
-rand = "0.8.5"
-sha2 = "0.10.2"
+rand = "^0.8"
+sha2 = "^0.10"
 
 [features]
 network = ["reqwest"]

--- a/src/chunk/manifest.rs
+++ b/src/chunk/manifest.rs
@@ -110,3 +110,9 @@ impl Manifest {
         manifest
     }
 }
+
+impl Default for Manifest {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/chunk/sync.rs
+++ b/src/chunk/sync.rs
@@ -157,12 +157,10 @@ impl<'a, T: ChunkProvider> Syncer<'a, T> {
             // First load all the chunk copies into memory.
             for operation in operations {
                 if let Operation::Copy(chunk) = operation {
-                    source_file
-                        .seek(SeekFrom::Start(chunk.offset))?;
+                    source_file.seek(SeekFrom::Start(chunk.offset))?;
 
                     let mut data = vec![0; chunk.length as usize];
-                    source_file
-                        .read_exact(&mut data)?;
+                    source_file.read_exact(&mut data)?;
 
                     have_chunks.insert(chunk.hash, data);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! two locations. The underlying algorithm used is based on fast content
 //! defined chunking. This works by first generating a `Manifest` that lists
 //! the files and chunks in the source folder. Using the `sync` function pointed
-//! at an empty or already populated destination folder the libray will migrate
+//! at an empty or already populated destination folder the library will migrate
 //! the contents of the destination to look like the source.
 //!
 //! ```rust,no_run
@@ -25,7 +25,12 @@ mod sync;
 #[cfg(feature = "network")]
 pub use chunk::network::{RemoteChunkProvider, RemoteManifest};
 
-pub use chunk::{manifest::Manifest, provider::CachingChunkProvider, sync::Syncer, ChunkProvider};
+pub use chunk::{
+    manifest::{FileChunkInfo, Manifest},
+    provider::CachingChunkProvider,
+    sync::Syncer,
+    Chunk, ChunkProvider,
+};
 pub use error::Error as BinsyncError;
 use std::path::Path;
 


### PR DESCRIPTION
This PR exposes additional structs to allow consumers to better interact with Manifests created by this crate. The additional structs are `chunk::Chunk` as well as `chunk::manifest::FileChunkInfo`.

Additionally, removed the restrictions on exact version matching on dependencies. Kept to all major version, but allowed minor upgrades to be adopted.